### PR TITLE
update natchez to 0.2.2 and implement new methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "org.tpolecat"                %%% "natchez-core"               % "0.2.2",
       "io.chrisdavenport"           %%% "fiberlocal"                 % "0.1.1",
       "org.typelevel"               %%% "munit-cats-effect-3"        % munitCatsEffectV         % Test,
-
+      "org.tpolecat"                %%% "natchez-noop"               % "0.2.2"                  % Test,
     )
   ).jsSettings(
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)},

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.1" // your current series x.y
+ThisBuild / tlBaseVersion := "0.2" // your current series x.y
 
 ThisBuild / organization := "io.chrisdavenport"
 ThisBuild / organizationName := "Christopher Davenport"
@@ -12,7 +12,7 @@ ThisBuild / tlSonatypeUseLegacyHost := true
 
 val Scala213 = "2.13.7"
 
-ThisBuild / crossScalaVersions := Seq("2.12.15", Scala213, "3.1.1")
+ThisBuild / crossScalaVersions := Seq("2.12.15", Scala213, "3.2.1")
 ThisBuild / scalaVersion := Scala213
 
 ThisBuild / testFrameworks += new TestFramework("munit.Framework")
@@ -35,7 +35,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies ++= Seq(
       "org.typelevel"               %%% "cats-core"                  % catsV,
       "org.typelevel"               %%% "cats-effect"                % catsEffectV,
-      "org.tpolecat"                %%% "natchez-core"               % "0.1.6",
+      "org.tpolecat"                %%% "natchez-core"               % "0.2.2",
       "io.chrisdavenport"           %%% "fiberlocal"                 % "0.1.1",
       "org.typelevel"               %%% "munit-cats-effect-3"        % munitCatsEffectV         % Test,
 

--- a/core/src/test/scala/io/chrisdavenport/natchezlocal/TraceLocalSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/natchezlocal/TraceLocalSpec.scala
@@ -1,0 +1,33 @@
+package io.chrisdavenport.natchezlocal
+
+import cats.effect.{Trace => _, _}
+import io.chrisdavenport.fiberlocal.FiberLocal
+import munit.CatsEffectSuite
+import natchez.Span
+import natchez.noop.NoopSpan
+
+class TraceLocalSpec extends CatsEffectSuite {
+
+  test("TraceLocal.spanR should restore the FiberLocal span and not the span in place when the FunctionK is created") {
+    val originalSpan: Span[IO] = NoopSpan[IO]()
+    val replacementSpan: Span[IO] = NoopSpan[IO]()
+
+    IOLocal(originalSpan)
+      .map(FiberLocal.fromIOLocal[IO, Span[IO]])
+      .flatMap { fiberLocal =>
+        val trace = TraceLocal.fromFiberLocal(fiberLocal)
+        trace.spanR("test").use { fk =>
+          for {
+            spanBeforeRunningFk <- fiberLocal.get
+            _ <- fiberLocal.set(replacementSpan)
+            _ <- fk(IO.unit)
+            spanAfterRunningFk <- fiberLocal.get
+          } yield {
+            assert(originalSpan eq spanBeforeRunningFk)
+            assert(replacementSpan eq spanAfterRunningFk)
+          }
+        }
+      }
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "0.4.9")
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.4.9")
 addSbtPlugin("org.typelevel" % "sbt-typelevel-settings" % "0.4.9")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.2.0")


### PR DESCRIPTION
I had to update the Scala 3 and Scala.js versions to work with the Natchez update.

The new method implementations were inspired by the existing TraceLocal and KleisliTrace implementations. It builds, but I haven't played with the new methods much so I'm not 100% sure if they're correct or not.